### PR TITLE
Update the create order flow to match new specification

### DIFF
--- a/app/src/components/CustomTable.tsx
+++ b/app/src/components/CustomTable.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
+
 interface CustomTableProps {
   headers: string[];
   data: any[][];

--- a/app/src/components/NewOrderForm.tsx
+++ b/app/src/components/NewOrderForm.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+import { Button } from "../components/Button";
+import { Col } from "../components/Layout";
+import { NumberedStep } from "../components/NumberedStep";
+import { SingleLineInput } from "../components/SingleLineInput";
+
+
+interface NewOrderFormProps {
+  newOrderAmount: number;
+  setNewOrderAmount: (amount: number) => void;
+  venmoIdEncryptingKey: string;
+  setVenmoIdEncryptingKey: (key: string) => void;
+  writeNewOrder?: () => void;
+  isWriteNewOrderLoading: boolean;
+}
+ 
+export const NewOrderForm: React.FC<NewOrderFormProps> = ({ newOrderAmount, setNewOrderAmount, venmoIdEncryptingKey, setVenmoIdEncryptingKey, writeNewOrder, isWriteNewOrderLoading }) => {
+  return (
+    <NewOrderFormContainer>
+      <NumberedStep step={1}>
+        Specify an amount to on-ramp.
+      </NumberedStep>
+      <NumberedStep step={2}>
+        Provide a public key that will be used to encrypt Venmo handles. You should use a separate asymmetric key pair than your on-ramping account.
+      </NumberedStep>
+      <SingleLineInput
+        label="Amount"
+        value={newOrderAmount}
+        onChange={(e) => {
+          setNewOrderAmount(e.currentTarget.value);
+        }}
+      />
+      <SingleLineInput
+        label="Encrypting Public Key"
+        value={venmoIdEncryptingKey}
+        onChange={(e) => {
+          setVenmoIdEncryptingKey(e.currentTarget.value);
+        }}
+      />
+      <Button
+        disabled={isWriteNewOrderLoading}
+        onClick={async () => {
+          writeNewOrder?.();
+        }}
+        >
+        Create
+      </Button>
+    </NewOrderFormContainer>
+  );
+};
+
+const NewOrderFormContainer = styled(Col)`
+  width: 100%;
+  gap: 1rem;
+  align-self: flex-start;
+`;

--- a/app/src/components/SingleLineInput.tsx
+++ b/app/src/components/SingleLineInput.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { Col } from "./Layout";
 
+
 export const SingleLineInput: React.FC<{
   label: string;
   value: any;
@@ -16,7 +17,12 @@ export const SingleLineInput: React.FC<{
       >
         {label}
       </label>
-      <Input onChange={onChange} value={value} placeholder={label} readOnly={readOnly} />
+      <Input
+        onChange={onChange}
+        value={value}
+        placeholder={label}
+        readOnly={readOnly}
+      />
     </InputContainer>
   );
 };


### PR DESCRIPTION
Minor tweaks to the create flow to match the new specification

<img width="1023" alt="Screenshot 2023-04-26 at 2 14 07 PM" src="https://user-images.githubusercontent.com/3453571/234704368-10c97767-5255-46da-8d37-aa3be7a5837e.png">

I need the new contract and interface before I can test a transaction. It doesn't prompt metamask when the parameter types are incorrect. 