### PR TITLE
Alex/claim order flow

### DIFF
--- a/app/src/components/ClaimOrderForm.tsx
+++ b/app/src/components/ClaimOrderForm.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+import { Button } from "../components/Button";
+import { Col, Row } from "../components/Layout";
+import { NumberedStep } from "../components/NumberedStep";
+import { ReadOnlyInput } from "../components/ReadOnlyInput";
+import { SingleLineInput } from "../components/SingleLineInput";
+
+import EthCrypto from 'eth-crypto';
+
+
+interface ClaimOrderFormProps {
+  senderAddress: string;
+  senderRequestedAmount: number;
+  venmoHandle: string;
+  setVenmoHandle: (amount: string) => void;
+  requestedUSDAmount: number;
+  setRequestedUSDAmount: (key: number) => void;
+  writeClaimOrder?: () => void;
+  isWriteClaimOrderLoading: boolean;
+}
+ 
+export const ClaimOrderForm: React.FC<ClaimOrderFormProps> = ({ senderAddress, senderRequestedAmount, venmoHandle, setVenmoHandle, requestedUSDAmount, setRequestedUSDAmount, writeClaimOrder, isWriteClaimOrderLoading }) => {
+  async function encryptWithPublicKey(text: string, publicKey: string) {
+    const entropy = Buffer.from('', 'utf-8');
+    const identity = EthCrypto.createIdentity(entropy);
+    console.log('Generated identity:');
+    console.log(identity);
+    
+    console.log('Passed in:');
+    console.log(text);
+    console.log(publicKey);
+
+    const genPublicKey = EthCrypto.publicKeyByPrivateKey('')
+    console.log('Generated Pubkey:');
+    console.log(genPublicKey);
+
+    const encrypted = await EthCrypto.encryptWithPublicKey(genPublicKey, text);
+    const encryptedString = EthCrypto.cipher.stringify(encrypted);
+    
+    console.log('Encrypted message:')
+    console.log(encryptedString);
+
+    const privateKey = '';
+    const encryptedObject = EthCrypto.cipher.parse(encryptedString);
+    const decrypted = await EthCrypto.decryptWithPrivateKey(privateKey, encryptedObject);
+
+    console.log('Decrypted message:')
+    console.log(decrypted);
+
+    return encryptedString;
+  };
+
+  return (
+    <ClaimOrderFormContainer>
+      <SelectedOrderContainer>
+        <ReadOnlyInput
+          label="Order Creator"
+          value={senderAddress}
+        />
+        <ReadOnlyInput
+          label="Amount (USDC)"
+          value={senderRequestedAmount}
+        />
+      </SelectedOrderContainer>
+      <hr />
+      <NumberedStep step={1}>
+        Provide a Venmo Handle to receive USD at. This will be encrypted using the key provided by the on-ramper
+      </NumberedStep>
+      <NumberedStep step={2}>
+        Specify the USD amount for the user to send. This amount will be sent by the on-ramper through Venmo
+      </NumberedStep>
+      <NumberedStep step={3}>
+        Submit a claim on the order on-chain. This will lock {senderRequestedAmount} USDC for the user to claim with a proof
+      </NumberedStep>
+      <hr />
+      <SingleLineInput
+        label="Venmo Handle"
+        value={venmoHandle}
+        placeholder={'Your-Venmo-Handle'}
+        onChange={(e) => {
+          setVenmoHandle(e.currentTarget.value);
+        }}
+      />
+      <SingleLineInput
+        label="USD Amount"
+        value={requestedUSDAmount}
+        placeholder={'0'}
+        onChange={(e) => {
+          setRequestedUSDAmount(e.currentTarget.value);
+        }}
+      />
+      <Button
+        disabled={isWriteClaimOrderLoading}
+        onClick={async () => {
+          await encryptWithPublicKey('0x0B8EBCC49Abe3E1Cae4c0364C25507241DdfFbbd', venmoHandle)
+
+          // writeClaimOrder?.();
+        }}
+        >
+        ClaimOrder
+      </Button>
+    </ClaimOrderFormContainer>
+  );
+};
+
+const SelectedOrderContainer = styled(Col)`
+  background: rgba(255, 255, 255, 0.1);
+  width: 100%;
+  gap: 1rem;
+  border-radius: 4px;
+  padding: 1rem;
+  margin: 0 -1rem;
+  color: #fff;
+`;
+
+const ClaimOrderFormContainer = styled(Col)`
+  width: 100%;
+  gap: 1rem;
+  align-self: flex-start;
+`;

--- a/app/src/components/ClaimOrderForm.tsx
+++ b/app/src/components/ClaimOrderForm.tsx
@@ -7,7 +7,6 @@ import { NumberedStep } from "../components/NumberedStep";
 import { ReadOnlyInput } from "../components/ReadOnlyInput";
 import { SingleLineInput } from "../components/SingleLineInput";
 
-import EthCrypto from 'eth-crypto';
 
 
 interface ClaimOrderFormProps {
@@ -22,36 +21,6 @@ interface ClaimOrderFormProps {
 }
  
 export const ClaimOrderForm: React.FC<ClaimOrderFormProps> = ({ senderAddress, senderRequestedAmount, venmoHandle, setVenmoHandle, requestedUSDAmount, setRequestedUSDAmount, writeClaimOrder, isWriteClaimOrderLoading }) => {
-  async function encryptWithPublicKey(text: string, publicKey: string) {
-    const entropy = Buffer.from('', 'utf-8');
-    const identity = EthCrypto.createIdentity(entropy);
-    console.log('Generated identity:');
-    console.log(identity);
-    
-    console.log('Passed in:');
-    console.log(text);
-    console.log(publicKey);
-
-    const genPublicKey = EthCrypto.publicKeyByPrivateKey('')
-    console.log('Generated Pubkey:');
-    console.log(genPublicKey);
-
-    const encrypted = await EthCrypto.encryptWithPublicKey(genPublicKey, text);
-    const encryptedString = EthCrypto.cipher.stringify(encrypted);
-    
-    console.log('Encrypted message:')
-    console.log(encryptedString);
-
-    const privateKey = '';
-    const encryptedObject = EthCrypto.cipher.parse(encryptedString);
-    const decrypted = await EthCrypto.decryptWithPrivateKey(privateKey, encryptedObject);
-
-    console.log('Decrypted message:')
-    console.log(decrypted);
-
-    return encryptedString;
-  };
-
   return (
     <ClaimOrderFormContainer>
       <SelectedOrderContainer>
@@ -76,9 +45,9 @@ export const ClaimOrderForm: React.FC<ClaimOrderFormProps> = ({ senderAddress, s
       </NumberedStep>
       <hr />
       <SingleLineInput
-        label="Venmo Handle"
+        label="Venmo ID"
         value={venmoHandle}
-        placeholder={'Your-Venmo-Handle'}
+        placeholder={'1234567891011121314'}
         onChange={(e) => {
           setVenmoHandle(e.currentTarget.value);
         }}
@@ -94,9 +63,7 @@ export const ClaimOrderForm: React.FC<ClaimOrderFormProps> = ({ senderAddress, s
       <Button
         disabled={isWriteClaimOrderLoading}
         onClick={async () => {
-          await encryptWithPublicKey('0x0B8EBCC49Abe3E1Cae4c0364C25507241DdfFbbd', venmoHandle)
-
-          // writeClaimOrder?.();
+          writeClaimOrder?.();
         }}
         >
         ClaimOrder
@@ -107,11 +74,9 @@ export const ClaimOrderForm: React.FC<ClaimOrderFormProps> = ({ senderAddress, s
 
 const SelectedOrderContainer = styled(Col)`
   background: rgba(255, 255, 255, 0.1);
-  width: 100%;
   gap: 1rem;
   border-radius: 4px;
   padding: 1rem;
-  margin: 0 -1rem;
   color: #fff;
 `;
 

--- a/app/src/components/NewOrderForm.tsx
+++ b/app/src/components/NewOrderForm.tsx
@@ -58,9 +58,11 @@ export const NewOrderForm: React.FC<NewOrderFormProps> = ({
       <NumberedStep step={2}>
         If this is your first time or if you are on a new browser, you'll be prompted to sign a message to encrypt Venmo handles
       </NumberedStep>
+      <hr />
       <SingleLineInput
-        label="Amount"
+        label="Amount (USDC)"
         value={newOrderAmount}
+        placeholder={'0'}
         onChange={(e) => {
           setNewOrderAmount(e.currentTarget.value);
         }}

--- a/app/src/components/NumberedStep.tsx
+++ b/app/src/components/NumberedStep.tsx
@@ -17,10 +17,9 @@ export const NumberedStep: React.FC<{
 
 const NumberedStepContainer = styled(Row)`
   background: rgba(255, 255, 255, 0.05);
-  width: 100%;
   gap: 1rem;
   border-radius: 4px;
-  padding: 8px;
+  padding: 12px 16px;
   color: #fff;
 `;
 

--- a/app/src/components/ReadOnlyInput.tsx
+++ b/app/src/components/ReadOnlyInput.tsx
@@ -7,11 +7,7 @@ export const ReadOnlyInput: React.FC<{
 }> = ({ label, value }) => {
   return (
     <InputContainer>
-      <label
-        style={{
-          color: "rgba(255, 255, 255, 0.8)",
-        }}
-      >
+      <label>
         {label}
       </label>
       <Input value={value} placeholder={label} readOnly={true} />
@@ -36,4 +32,5 @@ const Input = styled.input`
   user-select: none;
   -webkit-user-select: none;
   pointer-events: none;
+  opacity: 0.6;
 `;

--- a/app/src/components/SingleLineInput.tsx
+++ b/app/src/components/SingleLineInput.tsx
@@ -5,9 +5,10 @@ import { Col } from "./Layout";
 export const SingleLineInput: React.FC<{
   label: string;
   value: any;
+  placeholder: string;
   onChange: (e: any) => void;
   readOnly?: boolean;
-}> = ({ label, onChange, value, readOnly = false }) => {
+}> = ({ label, value, placeholder, onChange, readOnly = false }) => {
   return (
     <InputContainer>
       <label
@@ -20,7 +21,7 @@ export const SingleLineInput: React.FC<{
       <Input
         onChange={onChange}
         value={value}
-        placeholder={label}
+        placeholder={placeholder}
         readOnly={readOnly}
       />
     </InputContainer>

--- a/app/src/helpers/accountHash.ts
+++ b/app/src/helpers/accountHash.ts
@@ -21,3 +21,26 @@ export const getPublicKeyFromAccount = (account: string): string => {
 
   return identity.publicKey;
 }
+
+export async function encryptMessage(message: string, publicKey: string) {
+  const encrypted = await EthCrypto.encryptWithPublicKey(publicKey, message);
+  const encryptedString = EthCrypto.cipher.stringify(encrypted);
+
+  // console.log('Encrypted message:');
+  // console.log(encrypted);
+
+  return encryptedString;
+}
+
+export async function decryptMessageWithAccount(encrypted: string, account: string) {
+  const entropy = Buffer.from(account, 'utf-8');
+  const privateKey = EthCrypto.createIdentity(entropy).privateKey;
+
+  const encryptedObject = EthCrypto.cipher.parse(encrypted);
+  const decrypted = EthCrypto.decryptWithPrivateKey(privateKey, encryptedObject);
+
+  // console.log('Decrypted message:');
+  // console.log(decrypted);
+
+  return decrypted;
+}

--- a/app/src/pages/MainPage.tsx
+++ b/app/src/pages/MainPage.tsx
@@ -103,10 +103,9 @@ export const MainPage: React.FC<{}> = (props) => {
   const [newOrderAmount, setNewOrderAmount] = useState<number>(0);
   const [newOrderVenmoIdEncryptingKey, setNewOrderVenmoIdEncryptingKey] = useState<string>('');
 
-  const [claimOrderVenmoHandle, setClaimOrderVenmoHandle] = useState<string>('');
-  const [claimOrderRequestedAmount, setClaimOrderRequestedAmount] = useState<number>(0);
   const [claimOrderEncryptedVenmoHandle, setClaimOrderEncryptedVenmoHandle] = useState<string>('');
   const [claimOrderHashedVenmoHandle, setClaimOrderHashedVenmoHandle] = useState<string>('');
+  const [claimOrderRequestedAmount, setClaimOrderRequestedAmount] = useState<number>(0);
   
   const [actionState, setActionState] = useState<FormState>(FormState.DEFAULT);
   const [selectedOrder, setSelectedOrder] = useState<OnRampOrder>({} as OnRampOrder);
@@ -262,8 +261,8 @@ export const MainPage: React.FC<{}> = (props) => {
     functionName: 'postOrder',
     args: [
       formatAmountsForTransactionParameter(newOrderAmount),
-      formatAmountsForTransactionParameter(newOrderAmount)
-      // newOrderVenmoIdEncryptingKey
+      formatAmountsForTransactionParameter(newOrderAmount)  // TODO: Replace when new contract is deployed
+      // newOrderVenmoIdEncryptingKey                       // TODO: Update when new contract is deployed
     ],
     onError: (error: { message: any }) => {
       console.error(error.message);
@@ -282,7 +281,13 @@ export const MainPage: React.FC<{}> = (props) => {
     addressOrName: contractAddresses["goerli"]["ramp"],
     contractInterface: abi,
     functionName: 'claimOrder',
-    args: [selectedOrder.orderId],
+    args: [
+      selectedOrder.orderId
+      // formatAmountsForTransactionParameter(claimOrderRequestedAmount)  // TODO: Update when new contract is deployed
+      // claimOrderEncryptedVenmoHandle,                                  // TODO: Update when new contract is deployed
+      // claimOrderHashedVenmoHandle                                      // TODO: Update when new contract is deployed
+
+    ],
     onError: (error: { message: any }) => {
       console.error(error.message);
     },
@@ -582,12 +587,12 @@ export const MainPage: React.FC<{}> = (props) => {
           )}
           {actionState === FormState.CLAIM && (
             <ClaimOrderForm
-              senderAddress={selectedOrder.sender}
-              senderRequestedAmount={formatAmountsForUSDC(selectedOrder.amount)}
-              venmoHandle={claimOrderVenmoHandle}
-              setVenmoHandle={setClaimOrderVenmoHandle}
-              requestedUSDAmount={claimOrderRequestedAmount}
+              senderEncryptingKey={selectedOrder.encryptingKey}
+              senderAddressDisplay={selectedOrder.sender}
+              senderRequestedAmountDisplay={formatAmountsForUSDC(selectedOrder.amount)}
               setRequestedUSDAmount={setClaimOrderRequestedAmount}
+              setEncryptedVenmoHandle={setClaimOrderEncryptedVenmoHandle}
+              setHashedVenmoHandle={setClaimOrderHashedVenmoHandle}
               writeClaimOrder={writeClaimOrder}
               isWriteClaimOrderLoading={isWriteClaimOrderLoading}
             />

--- a/app/src/pages/MainPage.tsx
+++ b/app/src/pages/MainPage.tsx
@@ -349,7 +349,7 @@ export const MainPage: React.FC<{}> = (props) => {
         const amount = orderContractData[2].toString();
         const maxAmount = orderContractData[3].toString();
         const status = orderContractData[4];
-        const encryptingKey = '0x0B8EBCC49Abe3E1Cae4c0364C25507241DdfFbbd';
+        const encryptingKey = 'a19eb5cdd6b3fce15832521908e4f66817e9ea8728dde4469f517072616a590be610c8af6d616fa77806b4d3ac1176634f78cd29266b4bdae4110ac3cdeb9231';
 
         const order: OnRampOrder = {
           orderId,


### PR DESCRIPTION
Updates the claim order flow to match the new specifications

- Requests a USD amount and a Venmo Id (couldn't resolve the handle from the id due to CORS policy, will have to think of a creative solution here)
- Venmo Id is encrypted with order's provided encrypting key (checking a throw away one in)
- Venmo Id is hashed using Poseidon (still need to properly add the padded elements that the circuit is looking for)

<img width="854" alt="Screenshot 2023-04-28 at 12 55 54 PM" src="https://user-images.githubusercontent.com/3453571/235241165-4f34a8b6-c7e2-446e-aeb0-4e1215f20056.png">

